### PR TITLE
Updated example for Martin

### DIFF
--- a/modulated_sinewave_pacat.py
+++ b/modulated_sinewave_pacat.py
@@ -1,0 +1,41 @@
+import subprocess
+import numpy as np
+import math
+
+f = 440 # Hz
+lfo_f = 5.67 # Hz
+lfo_low = 0.1 # multiple of f
+lfo_high = 1.1 # multiple of f
+lfo_p = 0 #
+
+a = 0.1 # amplitude
+p = 0 # phase offse (0 .. 2π)
+
+buffersize = 256 # samples
+latency = 100 # ms
+rate = 48000 # Hz
+
+timestep_base = f * math.tau / rate # you can recaulcate this in the generator loop if you want to modulate the frequency
+lfo_timestep = lfo_f * math.tau / rate
+lfo_delta = lfo_high - lfo_low
+
+sound_buffer = np.array([0.0] * buffersize, np.float32) # this sound buffer can be reused over and over
+
+# output sound using Pulseaudio using Pacat and stdin
+output_sound = subprocess.Popen(('pacat', f'--latency-msec={latency}', '--format=float32ne', '--channels=1', f'--rate={rate}'), stdin=subprocess.PIPE)
+
+
+accumulator = p	#starting phase
+lfo_accumulator = lfo_p
+while True:
+	#Update buffer
+	for i in range(buffersize):
+		timestep = timestep_base * (np.sin(lfo_accumulator) * lfo_delta + lfo_low)
+
+		sound_buffer[i] = np.sin(accumulator) * a
+
+		accumulator = (accumulator + timestep) % math.tau
+		lfo_accumulator = (lfo_accumulator + lfo_timestep) % math.tau
+
+	#Play buffer (blocking)
+	output_sound.stdin.write(sound_buffer.tobytes()) #write buffer to stdin


### PR DESCRIPTION
## Changes
- The [entire buffer](https://github.com/Mikael-Lovqvist/sinewave_playback_example/blob/345c59b18394ce8e683271966256ed93f3e69364/sinewave_pacat.py#L15) is a [numpy array](https://numpy.org/devdocs/user/basics.types.html#array-types-and-conversions-between-types) which is efficient to work with
- The buffer is converted to bytes in one call
- The buffer is sent to the child process in one call
- Sample rate is used for [computing time step](https://github.com/Mikael-Lovqvist/sinewave_playback_example/blob/345c59b18394ce8e683271966256ed93f3e69364/sinewave_pacat.py#L13)
- Latency is now set in milliseconds
- Arguments of pacat match manpage
- Phase [accumulator update](https://github.com/Mikael-Lovqvist/sinewave_playback_example/blob/345c59b18394ce8e683271966256ed93f3e69364/sinewave_pacat.py#L26) is kept within bounds to stay within a known precision